### PR TITLE
feat(job-page): create job page and card components for listing jobs

### DIFF
--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->class(['bg-white w-full py-5 rounded-lg']) }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -10,7 +10,7 @@
 
 </head>
 
-<body>
+<body class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 w-full pt-10">
     {{ $slot }}
 </body>
 

--- a/resources/views/job/index.blade.php
+++ b/resources/views/job/index.blade.php
@@ -1,5 +1,5 @@
 <x-layout>
     @foreach ($jobs as $job)
-        <div class="text-3xl bg-gradient-to-b h-full text-transparent bg-clip-text from-black to-blue-600 ">{{ $job->title }}</div>
+        <x-card class="mb-2">{{ $job->title }}</x-card>
     @endforeach
 </x-layout>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,23 +2,30 @@ import defaultTheme from 'tailwindcss/defaultTheme';
 
 /** @type {import('tailwindcss').Config} */
 export default {
-    // content: [
-    //     './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
-    //     './storage/framework/views/*.php',
-    //     './resources/**/*.blade.php',
-    //     './resources/**/*.js',
-    //     './resources/**/*.vue',
-    // ],
     content: [
-        "./resources/**/*.blade.php",
-        "./resources/**/*.js",
-        "./resources/**/*.vue",
+        './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
+        './storage/framework/views/*.php',
+        './resources/**/*.blade.php',
+        './resources/**/*.js',
+        './resources/**/*.vue',
     ],
     theme: {
+        screens: {
+            sm: "375px",
+            md: "768px",
+            lg: "1200px",
+        },
         extend: {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            container: {
+                center: true,
+                padding: {
+                    DEFAULT: "10px",
+                    lg: "80px",
+                }
+            }
         },
     },
     plugins: [],


### PR DESCRIPTION
Created a job page component and a reusable job card component for displaying job listings. Used $slot for component reusability, allowing dynamic content to be passed into the card component. The job page now dynamically displays a list of jobs.

Refs: JOB-BOARD-004, #47