### PR TITLE
feat(employer): implement Employer table, migrations, and model relat…

### DIFF
--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Employer extends Model
+{
+    /** @use HasFactory<\Database\Factories\EmployerFactory> */
+    use HasFactory;
+
+    public function jobs(): HasMany {
+        return $this->hasMany(Job::class);
+    }
+
+    public function user():BelongsTo {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Job.php
+++ b/app/Models/Job.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class Job extends Model
@@ -14,7 +15,17 @@ class Job extends Model
 
     use HasFactory;
     public static array $experience = ['entry', 'intermidiate', 'senior'];
-    public static array $category = ['IT', 'Finance', 'Sales', 'Marketing'];
+    public static array $category = [
+        'IT',
+        'Finance',
+        'Sales',
+        'Marketing'
+    ];
+
+    public function employer(): BelongsTo
+    {
+        return $this->belongsTo(Employer::class);
+    }
 
     public function scopeFilter(Builder|QueryBuilder $query, array $filters): Builder|QueryBuilder
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -44,5 +45,9 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function employer():HasOne {
+        return $this->hasOne(Employer::class);
     }
 }

--- a/database/factories/EmployerFactory.php
+++ b/database/factories/EmployerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Employer>
+ */
+class EmployerFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/2024_11_23_112633_create_employers_table.php
+++ b/database/migrations/2024_11_23_112633_create_employers_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employers', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('company_name');
+            $table->foreignIdFor(\App\Models\User::class)->nullable()->constrained();
+
+            $table->timestamps();
+        });
+
+        Schema::table('jobs', function (Blueprint $table) {
+            $table->foreignIdFor(\App\Models\Employer::class)->constrained();
+        });
+    }
+
+
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('jobs', function (Blueprint $table) {
+            $table->dropForeignIdFor(\App\Models\Employer::class);
+        });
+
+        Schema::dropIfExists('employers');
+    }
+};


### PR DESCRIPTION
feat(employer): implement Employer table, migrations, and model relations

Created the `employers` table with necessary columns and established foreign key relations to `users` and `jobs`.  
Defined relationships in the `Employer`, `Job`, and `User` models:
- `Employer` has many `Jobs` and belongs to `User`.
- `User` has one `Employer`.
- `Job` belongs to an `Employer`.

Added nullable constraint to the foreign key in `employers` to allow flexibility for users who are not employers.

Performed `php artisan db:wipe && php artisan migrate` to reset the database and apply the new changes.  
**Note:** This action should only be executed in testing or local environments and never in production.

Refs: JOB-BOARD-009, #52