### PR TITLE
feat(job-page): display other jobs by the same employer

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -43,9 +43,9 @@ class JobController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(Job $job)
+    public function show(Job $job) //Route model binding;
     {
-        return view('job.show', ['job' => $job->load('employer')]);
+        return view('job.show', ['job' => $job->load('employer.jobs')]);
     }
 
     /**

--- a/resources/views/components/job-card.blade.php
+++ b/resources/views/components/job-card.blade.php
@@ -1,4 +1,4 @@
-<x-card class="mb-2">
+<x-card class="mb-2 px-5">
     <div>
         <div class="mb-4 flex justify-between">
             <h2 class="text-lg font-medium">

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -10,7 +10,7 @@
 
 </head>
 
-<body class="bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 w-full pt-10 max-w-2xl mx-auto">
+<body class="bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 w-full md:p-0 px-5 pt-10 max-w-2xl mx-auto">
     {{ $slot }}
 </body>
 

--- a/resources/views/job/show.blade.php
+++ b/resources/views/job/show.blade.php
@@ -5,4 +5,27 @@
             {!! nl2br(e($job->description)) !!}
         </p>
     </x-job-card>
+    <x-card class="mb-4">
+        <h2 class="mb-4 text-lg font-medium capitalize">More {{ $job->employer->company_name }} Jobs </h2>
+
+        <div class="text-sm text-slate-500">
+            @foreach ($job->employer->jobs as $otherJobs)
+                <div class="mb-4 flex justify-between">
+                    <div>
+                        <div class="text-slate-700">
+                            <a href="{{ route('jobs.show', $otherJobs)}}">
+                                {{$otherJobs->title}}
+                            </a>
+                        </div>
+                        <div class="text-sm text-slate-400">
+                            {{ $otherJobs->created_at->diffForHumans()}}
+                        </div>
+                    </div>
+                    <div aria-colspan="text-xs">
+                        ${{ number_format($otherJobs->salary)}}
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </x-card>
 </x-layout>


### PR DESCRIPTION
Added functionality to display a list of other jobs by the same employer on the job details page. Implemented a relationship in the  model to retrieve jobs from the same employer. Updated the job details view to include a section for other jobs by the employer, excluding the current job. Enhanced user experience by providing relevant job suggestions from the employer.

Refs: JOB-BOARD-012, #55