### PR TITLE
feat(auth): set up basic authentication routes and views

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AuthController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('auth.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/resources/views/auth/create.blade.php
+++ b/resources/views/auth/create.blade.php
@@ -1,0 +1,5 @@
+<x-layout>
+    <x-card>
+        Something here
+    </x-card>
+</x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,14 @@
 <?php
 
+use App\Http\Controllers\AuthController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\JobController;
 
-Route::get('', fn() => to_route('jobs.index'));
+Route::get('', fn() => to_route('jobs.index')); // automatic redirect function route;
+
 Route::resource('jobs', JobController::class)
-    ->only(['index', 'show'])
-;
+    ->only(['index', 'show']);
+
+Route::get('login', fn() => to_route('auth.create'))->name('login');
+Route::resource('auth', AuthController::class)
+    ->only(['create', 'store']);


### PR DESCRIPTION
feat(auth): set up basic authentication routes and views

Created `AuthController` to handle authentication-related views and logic.  
Added `create.blade.php` under the `auth` folder for user login/registration display.  
Configured routes in `web.php` for authentication, including redirection from `/login` to `/auth/create`.  
Verified routes with `php artisan route:list` to ensure proper setup.

Refs: JOB-BOARD-013, #56