### PR TITLE
feat(auth): implement sign-in logic in AuthController

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -3,60 +3,35 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class AuthController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
 
-    /**
-     * Show the form for creating a new resource.
-     */
     public function create()
     {
         return view('auth.create');
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request)
     {
-        //
+        $request->validate([
+            'email' => 'required|email',
+            'password' => 'required'
+        ]);
+
+        $credentials = $request->only('email', 'password');
+        $remember = $request->filled('remember');
+
+        if (Auth::attempt($credentials, $remember)) {
+            return redirect()->intended('/');
+        } else {
+            return redirect()->back()
+            ->with('error', 'Invalid credentials');
+        }
     }
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
 
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(string $id)
     {
         //

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        User::factory()->create([
+            'name' => 'Lewis Meta',
+            'email' => 'lewis@example.com',
+        ]);
+
         // User::factory(10)->create();
         \App\Models\User::factory(300)->create();
 
@@ -31,10 +36,5 @@ class DatabaseSeeder extends Seeder
                 'employer_id' => $employers->random()->id,
             ]);
         }
-
-        // User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
     }
 }

--- a/resources/views/auth/create.blade.php
+++ b/resources/views/auth/create.blade.php
@@ -10,7 +10,7 @@
             </div>
             <div class="mb-8">
                 <label for="password" class="mb-2 block text-slate-800">Password</label>
-                <x-text-input name="email" placeholder="Your password" type="password" />
+                <x-text-input name="password" placeholder="Your password" type="password" />
             </div>
 
             <div class="flex items-center justify-between text-sm font-medium">

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -10,7 +10,11 @@
 
 </head>
 
-<body class="bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 w-full md:p-0 px-5 pt-10 max-w-2xl mx-auto">
+<body 
+class="mx-auto w-full max-w-2xl bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 px-5 pt-10 md:p-0"
+>
+{{ auth()->user()->name ?? "Guest"}}
+
     {{ $slot }}
 </body>
 


### PR DESCRIPTION
feat(auth): implement sign-in logic in AuthController

Added authentication logic in `AuthController` to handle user sign-in.  
Created a test user and performed `php artisan migrate:refresh --seed` to update the database without losing data.  
Validated email input and made password field required for sign-in functionality.

Refs: JOB-BOARD-014, #58